### PR TITLE
Don't fail when tagging the docker image

### DIFF
--- a/.github/actions/aws-docker-tag/action.yml
+++ b/.github/actions/aws-docker-tag/action.yml
@@ -20,5 +20,8 @@ runs:
     - name: Tag Docker Image
       shell: bash
       run: |
-        MANIFEST=$(aws ecr batch-get-image --repository-name ${{ inputs.repository }} --image-ids imageTag=${{ inputs.sourceTag }} --output json | jq --raw-output --join-output '.images[0].imageManifest')
-        aws ecr put-image --repository-name ${{ inputs.repository }} --image-tag ${{ inputs.targetTag }} --image-manifest "$MANIFEST"
+        EXISTING_TARGET_IMAGE_MANIFEST=$(aws ecr batch-get-image --repository-name ${{ inputs.repository }} --image-ids imageTag=${{ inputs.targetTag }} --output json)
+        if echo "${EXISTING_TARGET_IMAGE_MANIFEST}" | grep 'Requested image not found'; then
+          MANIFEST=$(aws ecr batch-get-image --repository-name ${{ inputs.repository }} --image-ids imageTag=${{ inputs.sourceTag }} --output json | jq --raw-output --join-output '.images[0].imageManifest')
+          aws ecr put-image --repository-name ${{ inputs.repository }} --image-tag ${{ inputs.targetTag }} --image-manifest "$MANIFEST"
+        fi

--- a/.github/workflows/aws-docker-deploy.yml
+++ b/.github/workflows/aws-docker-deploy.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Configure AWS Credentials
-        uses: ingeno/aws-workflows/.github/actions/configure-aws-credentials@main
+        uses: ingeno/aws-workflows/.github/actions/configure-aws-credentials@v1
         with:
           aws-account-id: ${{ vars.SHARED_SERVICES_ACCOUNT_ID }}
           aws-region: ${{ vars.AWS_REGION }}
@@ -37,7 +37,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v1
 
       - name: Build, tag and Push image
-        uses: ingeno/aws-workflows/.github/actions/docker-deploy@main
+        uses: ingeno/aws-workflows/.github/actions/docker-deploy@v1
         with:
           registry: ${{ vars.SHARED_SERVICES_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com
           repository: ${{ inputs.repository }}


### PR DESCRIPTION
The use case here is a workflow rerun when a step within the deploy
workflow failed. Once the tag is added to the image, subsequent runs
would fail as AWS throws an error at the put-image command when the tag
to add already exists on the image.

I didn't find any option on the put-image command to silent this sort of
operation, neither did I find a command to list current image tags (in
the docker sense, not aws resource tags).